### PR TITLE
chore(code_quality): add hooks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "codeception/codeception": "^2.4",
         "wikimedia/composer-merge-plugin": "^1.4",
         "crazyfactory/sniffs": "^1.2"
+        "brainmaestro/composer-git-hooks": "^2.4"
     },
     "extra": {
         "merge-plugin": {
@@ -32,6 +33,11 @@
             "merge-extra": false,
             "merge-extra-deep": false,
             "merge-scripts": true
+        },
+       "hooks": {
+            "pre-commit": "composer lint",
+            "commit-msg": "",
+            "pre-push": "composer test"
         }
     },
     "license": "GPL",
@@ -42,6 +48,8 @@
         }
     ],
     "scripts": {
+        "post-install-cmd": "vendor/bin/cghooks add --ignore-lock",
+        "post-update-cmd": "vendor/bin/cghooks update",
         "test": "codecept run",
         "test:coverage": "codecept run unit --coverage --coverage-xml --coverage-html",
         "lint": "phpcs --standard=phpcs.xml",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "codeception/codeception": "^2.4",
         "wikimedia/composer-merge-plugin": "^1.4",
-        "crazyfactory/sniffs": "^1.2"
+        "crazyfactory/sniffs": "^1.2",
         "brainmaestro/composer-git-hooks": "^2.4"
     },
     "extra": {
@@ -48,8 +48,8 @@
         }
     ],
     "scripts": {
-        "post-install-cmd": "vendor/bin/cghooks add --ignore-lock",
-        "post-update-cmd": "vendor/bin/cghooks update",
+        "post-install-cmd": "cghooks add --ignore-lock",
+        "post-update-cmd": "cghooks update",
         "test": "codecept run",
         "test:coverage": "codecept run unit --coverage --coverage-xml --coverage-html",
         "lint": "phpcs --standard=phpcs.xml",


### PR DESCRIPTION
have a look at this, for now, we're not validating commitmsg, but we will in future, (that's a different story)

As of now the idea is: hooks will be synced with internal git hooks that package will take care of that, will be done automatically and user doesn't need to know about that.

closes #1 

second commit: I had some other changes which I hadn't commited 😄 sorry about that.

edit: since I had to have some changes on my composer.json, and I couldn't use lock file, I'll mark this as WIP and continue on tuesday (or lalita can simply update lock file and commit to this branch, once it passes, we can merge to master)